### PR TITLE
Adding ability to view logs for sub pods

### DIFF
--- a/lib/kubectl.js
+++ b/lib/kubectl.js
@@ -137,7 +137,17 @@ Kubectl.prototype.logs = function(name, done)
 	if( this.type !== 'pods' )
 		throw new Error('not a function')
 
-	this.spawn(['logs', name], function(err, data){
+	var action = new Array('logs');
+
+	if (name.indexOf(' ') > -1) {
+		var names = name.split(/ /);
+		action.push(names[0]);
+		action.push(names[1]);
+	} else {
+		action.push(name);
+	}
+
+	this.spawn(action, function(err, data){
 		done(err, data)
 	})
 }


### PR DESCRIPTION
I need the ability to view logs for sub-pods. The kubectl command allows you to do this by adding container ids to the end of the command separated by spaces. Spawn was sending the two names as a single quoted parameter. This allows you to send 2 distinct pod ids to the logs command.