### PR TITLE
Added ability to configure kubectl via kubeconfig rather than point a…

### DIFF
--- a/lib/kubectl.js
+++ b/lib/kubectl.js
@@ -4,12 +4,24 @@ function Kubectl(type, conf){
 	this.type = type
 	this.binary = conf.binary || 'kubectl'
 	
-	this.endpoint = conf.endpoint
+	this.kubeconfig = conf.kubeconfig || ''
+	this.endpoint = conf.endpoint || ''
 }
 
 Kubectl.prototype.spawn = function(args, done)
 {
-	var kube = spawn(this.binary, ['-s', this.endpoint ].concat(args))
+	var ops = new Array();
+
+	// Prefer configuration file over endpoint if both are defined
+	if (this.kubeconfig) {
+		ops.push('--kubeconfig')
+		ops.push(this.kubeconfig)
+	} else {
+		ops.push('-s')
+		ops.push(this.endpoint)
+	}
+
+	var kube = spawn(this.binary, ops.concat(args))
 		, stdout = ''
 		, stderr = ''
 	


### PR DESCRIPTION
…t an endpoint.

 - Kubeconfig is preferred if it exists
 - Currently endpoint and kubeconfig are mutually exclusive at this time
 - Backwards compatible

```
var k = require('k8s');

// Configure using endpoint
var kube = k.kubectl({
	endpoint: 'http://my-cluster'
	,binary: '/bin/kubectl'
	,version: 'v1'
});

// Configure using kubeconfig
var kube = k.kubectl({
	binary: '/bin/kubectl'
	,kubeconfig: '/etc/cluster1.yaml'
	,version: 'v1'
});
```