### PR TITLE
Additions from various forks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 node_modules
 typings
 npm-debug.log
-index.js
 .idea
+
+# Generated JS files
+index.js
+lib/*.js*

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ var kubectl = K8s.kubectl({
 //use restful api
 var kubeapi = K8s.api({
 	endpoint: 'http://192.168.10.10:8080'
-	, version: 'v1'
+	, version: '/api/v1'
 })
 
 // Configure using kubeconfig
 var kube = k.kubectl({
 	binary: '/bin/kubectl'
 	,kubeconfig: '/etc/cluster1.yaml'
-	,version: 'v1'
+	,version: '/api/v1'
 });
 
 ```

--- a/lib/kubectl.ts
+++ b/lib/kubectl.ts
@@ -207,7 +207,7 @@ class Kubectl
 
     public rollingUpdateByFile(name: string, filepath: string, flags?, done?: (err, data)=>void)
     {
-        if( this.type !== 'rc' )
+        if( this.type !== 'replicationcontrollers' )
             throw new Error('not a function')
 
         
@@ -225,7 +225,7 @@ class Kubectl
 
     public rollingUpdate(name: string, image: string, flags?, done?: (err, data)=>void)
     {
-        if( this.type !== 'rc' )
+        if( this.type !== 'replicationcontrollers' )
             throw new Error('not a function') 
         
 
@@ -243,7 +243,7 @@ class Kubectl
 
     public scale(name: string, replicas: string, flags?, done?: (err, data)=>void)
     {
-        if( this.type !== 'rc' )
+        if( this.type !== 'replicationcontrollers' )
             throw new Error('not a function')
         
         if( _.isFunction(flags) ){
@@ -334,15 +334,24 @@ declare function require(name:string)
 export = (conf)=>
 {
 	return {
+    // short names are just aliases to longer names
 		pod: new Kubectl('pods', conf)
-		, rc: new Kubectl('rc', conf)
-		, service: new Kubectl('service', conf)
-		, node: new Kubectl('node', conf)
-		, namespace: new Kubectl('namespace', conf)
-		, deployment: new Kubectl('deployment', conf)
-		, ds: new Kubectl('ds', conf)
+		, po: new Kubectl('pods', conf)
+		, replicationcontroller: new Kubectl('replicationcontrollers', conf)
+		, rc: new Kubectl('replicationcontrollers', conf)
+		, service: new Kubectl('services', conf)
+		, svc: new Kubectl('services', conf)
+		, node: new Kubectl('nodes', conf)
+		, no: new Kubectl('nodes', conf)
+		, namespace: new Kubectl('namespaces', conf)
+		, ns: new Kubectl('namespaces', conf)
+		, deployment: new Kubectl('deployments', conf)
+		, daemonset: new Kubectl('daemonsets', conf)
+		, ds: new Kubectl('daemonsets', conf)
 		, secrets: new Kubectl('secrets', conf)
 		, endpoint: new Kubectl('endpoints', conf)
+		, ep: new Kubectl('endpoints', conf)
 		, ingress: new Kubectl('ingress', conf)
+		, ing: new Kubectl('ingress', conf)
 	}
 }

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -29,7 +29,7 @@ class Request
         if (conf.hasOwnProperty("strictSSL") && conf.strictSSL === false)
             this.ignoreCerts = true;
 
-        this.domain = conf.endpoint + '/api/' + conf.version + '/'
+        this.domain = conf.endpoint + conf.version + '/'
     }
 
     private callbackFunction(primise, callback)

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "k8s",
-  "version": "0.2.10",
+  "version": "0.3.0",
   "author": "junjun16818",
   "description": "Node.js client library for Google's Kubernetes Kubectl And API",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/goyoo/node-kubernetes-clinet.git"
+    "url": "git+https://github.com/goyoo/node-k8s-client.git"
   },
   "bugs": {
-    "url": "http://github.com/goyoo/node-kubernetes-clinet/issues"
+    "url": "https://github.com/goyoo/node-k8s-client/issues"
   },
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "concurrently": "^2.0.0",
     "fast-json-patch": "^0.5.7",
     "json-loader": "^0.5.4",
+    "mocha": "^2.5.3",
     "ts-loader": "^0.8.2",
+    "tsd": "^0.6.5",
     "typescript": "^1.8.10",
     "webpack": "^1.13.1"
   },

--- a/test/kubeapi.js
+++ b/test/kubeapi.js
@@ -9,7 +9,7 @@ const expect = require('chai').expect
 
 var kubeapi = K8s.api({
 	endpoint: 'http://172.18.18.101:8080'
-	, version: 'v1'
+	, version: '/api/v1'
 })
 
 describe('kubeapi ',function() 


### PR DESCRIPTION
I've combined a few of the forks that I saw as each have slightly different functionality and I think it would be good to have them all together. I need client certificate auth so I'll be adding that soon as well.

Are there any instructions for running the tests? I can see it seems to link to a local Kubernetes, is it just a case of linking it to a cluster with admin permissions? Maybe we could use [minikube](https://github.com/kubernetes/minikube) in the tests.