### PR TITLE
Typescript 2 improvements

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -8,4 +8,4 @@ namespace K8s {
     export var kubectl = require('./lib/kubectl');
 }
 
-export default K8s;
+export = K8s;

--- a/index.ts
+++ b/index.ts
@@ -8,4 +8,4 @@ namespace K8s {
     export var kubectl = require('./lib/kubectl');
 }
 
-export = K8s;
+export default K8s;

--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,10 @@
-import _api = require('./lib/request');
+import { Request } from './lib/request';
 
 namespace K8s {
-    export type K8sRequest = _api.Request;
-    export var api = require('./lib/request');
+    export type K8sRequest = Request;
+    export var api = (conf) => {
+        return new Request(conf);
+    };
     export var kubectl = require('./lib/kubectl');
 }
 

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -5,7 +5,7 @@ const Observable = Rx.Observable
 
 declare var Buffer
 
-class Request
+export class Request
 {
     private strictSSL
     private domain

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -216,9 +216,3 @@ export class Request
         return source
     }
 }
-
-declare function require(name:string)
-
-export default (conf)=>{
-    return new Request(conf)
-}


### PR DESCRIPTION
Here we go with the fixes.

Also merged your improvements!

I kept it going with the more common syntax of the exports, but kept the one to fix your issue in your comment at #16 

Now you can use it like:
```
var K8s = require('k8s');
console.log(K8s.api);
```
That results a callable function, while in Typescript / ES6 projects one can use:
```
import * as K8s from 'k8s';
console.log(K8s.api);
```
and get the same function.