### PR TITLE
Fix HTTP headers for PATCH request

### DIFF
--- a/lib/request.ts
+++ b/lib/request.ts
@@ -138,9 +138,7 @@ export class Request
         {
             const options = this.getRequestOptions(url, { json:  body })
 
-            options.headers = {
-                'Content-Type': 'application/json-patch+json'
-            }
+            options.headers['Content-Type'] = 'application/strategic-merge-patch+json';
 
             request.patch(options, function(err, res, data)
             {

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -44,15 +44,17 @@ export class Request
         options.strictSSL = this.strictSSL
 
         if (this.auth) {
+            if (this.auth.caCert) {
+		options.ca = this.auth.caCert
+            }
             if (this.auth.username && this.auth.password) {
                 const authstr = new Buffer(this.auth.username + ':' + this.auth.password).toString('base64')
                 options.headers.Authorization = `Basic ${authstr}`
             } else if (this.auth.token) {
                 options.headers.Authorization = `Bearer ${this.auth.token}`
-            } else if (this.auth.clientCert && this.auth.clientKey && this.auth.caCert) {
+            } else if (this.auth.clientCert && this.auth.clientKey) {
                 options.cert = this.auth.clientCert
                 options.key = this.auth.clientKey
-                options.ca = this.auth.caCert
             }
         }
 


### PR DESCRIPTION
- Do not override all HTTP headers (eg. `Authorization`)
- Use the correct Content-Type (`application/strategic-merge-patch+json` instead of `application/json-patch+json`)