### PR TITLE
Add 'context' to conf

### DIFF
--- a/lib/kubectl.ts
+++ b/lib/kubectl.ts
@@ -8,6 +8,7 @@ class Kubectl
     private kubeconfig
     private namespace
     private endpoint
+    private context
 
     constructor(type, conf)
     {
@@ -16,6 +17,7 @@ class Kubectl
         this.kubeconfig = conf.kubeconfig || ''
         this.namespace = conf.namespace || ''
         this.endpoint = conf.endpoint || ''
+        this.context = conf.context || ''
     }
 
     private spawn(args, done)
@@ -32,6 +34,10 @@ class Kubectl
         
         if (this.namespace) {
             ops.push('--namespace='+this.namespace)
+        }
+
+        if (this.context) {
+            ops.push('--context='+this.context)
         }
 
         const kube = spawn(this.binary, ops.concat(args))
@@ -353,7 +359,8 @@ export = (conf):any=>
 		, ep: new Kubectl('endpoints', conf)
 		, ingress: new Kubectl('ingress', conf)
 		, ing: new Kubectl('ingress', conf)
-		, job: new Kubectl('job', conf)
+        , job: new Kubectl('job', conf)
+        , context: new Kubectl('context', conf)
         , command: function(){
             arguments[0] = arguments[0].split(' ')
             return this.pod.command.apply(this.pod, arguments)

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -17,7 +17,7 @@ export class Request
     {
         if (conf.kubeconfig) {
             var kubeconfig = jsyaml.safeLoad(fs.readFileSync(conf.kubeconfig))
-            var context = this.readContext(kubeconfig)
+            var context = conf.context || this.readContext(kubeconfig)
             var cluster = this.readCluster(kubeconfig, context)
             var user = this.readUser(kubeconfig, context)
         }


### PR DESCRIPTION
Add support for 'context'. If there is no 'context' in the config, then use `this.readContext(kubeconfig)` as before.